### PR TITLE
Turn fonts into a valid Windows font family

### DIFF
--- a/README
+++ b/README
@@ -23,10 +23,10 @@ Font Descriptions
 Level 1 Core Fonts
 
 - Corpus - Courier
-  Medium, Bold
+  Medium, Medium Oblique, Bold, Bold Oblique
 
 - Homerton - Helvetica
-  Medium, Bold
+  Medium, Medium Oblique, Bold, Bold Oblique
 
 - Trinity - Times New Roman
   Medium, Medium Oblique, Bold, Bold Oblique
@@ -60,7 +60,9 @@ directory.
 Four oblique fonts (Corpus Medium Oblique, Corpus Bold Oblique, Homerton
 Medium Oblique, Homerton Bold Oblique) could not be automatically
 converted with acorn2sfd as they are in a different font format that
-it did not understand.
+it did not understand.  The outlines file contains matrix transform values
+that describe how the Oblique fonts are generated from the base fonts.  The
+generation scripts recreate this transform assuming a skew of 12 degrees.
 
 Sassoon Primary and Sassoon Primary Bold currently have the wrong font
 encoding due to a segfault with acorn2sfd when using the Base0 encoding.

--- a/README
+++ b/README
@@ -66,3 +66,6 @@ generation scripts recreate this transform assuming a skew of 12 degrees.
 
 Sassoon Primary and Sassoon Primary Bold currently have the wrong font
 encoding due to a segfault with acorn2sfd when using the Base0 encoding.
+
+Some of the glyphs in Trinity Bold are malformed, causing too much space
+above the rendered font, so have been removed from the generated .sfd file.

--- a/Tools/FontConvert.sh
+++ b/Tools/FontConvert.sh
@@ -9,6 +9,13 @@
 # fontforge-nox
 
 
+dofontimage() {
+	sfdname="$1"
+	pngname=`basename "$sfdname" .sfd`.png
+
+	fontimage -o "$pngname" "$sfdname"
+}
+
 cd ..
 
 mkdir -p Fonts
@@ -47,14 +54,22 @@ cd ../..
 # Covert fonts to sfd format
 cd ../Fonts
 
+cp -f ../tmp/ROMFonts/Fonts/Corpus/Bold/Outlines0 ../tmp/ROMFonts/Fonts/Corpus/Bold/Oblique
+acorn2sfd ../tmp/ROMFonts/Fonts/Corpus/Bold/Oblique/
+sed "s/Corpus.Bold/Corpus.Bold.Oblique/" Corpus.Bold.sfd > Corpus.Bold.Oblique.sfd
 acorn2sfd ../tmp/ROMFonts/Fonts/Corpus/Bold/
-#acorn2sfd ../tmp/ROMFonts/Fonts/Corpus/Bold/Oblique/ Generates Error!
+cp -f ../tmp/ROMFonts/Fonts/Corpus/Medium/Outlines0 ../tmp/ROMFonts/Fonts/Corpus/Medium/Oblique
+acorn2sfd ../tmp/ROMFonts/Fonts/Corpus/Medium/Oblique/
+sed "s/Corpus.Medium/Corpus.Medium.Oblique/" Corpus.Medium.sfd > Corpus.Medium.Oblique.sfd
 acorn2sfd ../tmp/ROMFonts/Fonts/Corpus/Medium/
-#acorn2sfd ../tmp/ROMFonts/Fonts/Corpus/Medium/Oblique/ Generates Error!
+cp -f ../tmp/ROMFonts/Fonts/Homerton/Bold/Outlines0 ../tmp/ROMFonts/Fonts/Homerton/Bold/Oblique
+acorn2sfd ../tmp/ROMFonts/Fonts/Homerton/Bold/Oblique/
+sed "s/Homerton.Bold/Homerton.Bold.Oblique/" Homerton.Bold.sfd > Homerton.Bold.Oblique.sfd
 acorn2sfd ../tmp/ROMFonts/Fonts/Homerton/Bold/
-#acorn2sfd ../tmp/ROMFonts/Fonts/Homerton/Bold/Oblique/ Generates Error!
+cp -f ../tmp/ROMFonts/Fonts/Homerton/Medium/Outlines0 ../tmp/ROMFonts/Fonts/Homerton/Medium/Oblique
+acorn2sfd ../tmp/ROMFonts/Fonts/Homerton/Medium/Oblique/
+sed "s/Homerton.Medium/Homerton.Medium.Oblique/" Homerton.Medium.sfd > Homerton.Medium.Oblique.sfd
 acorn2sfd ../tmp/ROMFonts/Fonts/Homerton/Medium/
-#acorn2sfd ../tmp/ROMFonts/Fonts/Homerton/Medium/Oblique/ Generates Error!
 acorn2sfd ../tmp/ROMFonts/Fonts/Selwyn/
 acorn2sfd ../tmp/ROMFonts/Fonts/Sidney/
 acorn2sfd ../tmp/ROMFonts/Fonts/Trinity/Bold/
@@ -78,9 +93,13 @@ rm -rf ../tmp
 
 # Update fonts to correct their drawing direction and save out .otf versions of all fonts
 ../Tools/fontmunge.pe Corpus.Bold.sfd
+../Tools/fontmunge.pe Corpus.Bold.Oblique.sfd
 ../Tools/fontmunge.pe Corpus.Medium.sfd
+../Tools/fontmunge.pe Corpus.Medium.Oblique.sfd
 ../Tools/fontmunge.pe Homerton.Bold.sfd
+../Tools/fontmunge.pe Homerton.Bold.Oblique.sfd
 ../Tools/fontmunge.pe Homerton.Medium.sfd
+../Tools/fontmunge.pe Homerton.Medium.Oblique.sfd
 ../Tools/fontmunge.pe Selwyn.sfd
 ../Tools/fontmunge.pe Sidney.sfd
 ../Tools/fontmunge.pe Trinity.Bold.Italic.sfd
@@ -100,25 +119,25 @@ rm -rf ../tmp
 
 
 # Create preview images of the fonts
-fontimage Corpus.Bold.sfd
-fontimage Corpus.Medium.sfd
-fontimage Homerton.Bold.sfd
-fontimage Homerton.Medium.sfd
-fontimage Selwyn.sfd
-fontimage Sidney.sfd
-fontimage Trinity.Bold.Italic.sfd
-fontimage Trinity.Bold.sfd
-fontimage Trinity.Medium.Italic.sfd
-fontimage Trinity.Medium.sfd
+dofontimage Corpus.Bold.sfd
+dofontimage Corpus.Medium.sfd
+dofontimage Homerton.Bold.sfd
+dofontimage Homerton.Medium.sfd
+dofontimage Selwyn.sfd
+dofontimage Sidney.sfd
+dofontimage Trinity.Bold.Italic.sfd
+dofontimage Trinity.Bold.sfd
+dofontimage Trinity.Medium.Italic.sfd
+dofontimage Trinity.Medium.sfd
 
-fontimage NewHall.Bold.sfd
-fontimage NewHall.Bold.Italic.sfd
-fontimage NewHall.Medium.sfd
-fontimage NewHall.Medium.Italic.sfd
-fontimage Sassoon.Primary.sfd
-fontimage Sassoon.Primary.Bold.sfd
-fontimage System.Fixed.sfd
-fontimage System.Medium.sfd
+dofontimage NewHall.Bold.sfd
+dofontimage NewHall.Bold.Italic.sfd
+dofontimage NewHall.Medium.sfd
+dofontimage NewHall.Medium.Italic.sfd
+dofontimage Sassoon.Primary.sfd
+dofontimage Sassoon.Primary.Bold.sfd
+dofontimage System.Fixed.sfd
+dofontimage System.Medium.sfd
 
 
 

--- a/Tools/FontConvert.sh
+++ b/Tools/FontConvert.sh
@@ -103,6 +103,7 @@ rm -rf ../tmp
 ../Tools/fontmunge.pe Selwyn.sfd
 ../Tools/fontmunge.pe Sidney.sfd
 ../Tools/fontmunge.pe Trinity.Bold.Italic.sfd
+../Tools/Trinity.Bold.pe Trinity.Bold.sfd
 ../Tools/fontmunge.pe Trinity.Bold.sfd
 ../Tools/fontmunge.pe Trinity.Medium.Italic.sfd
 ../Tools/fontmunge.pe Trinity.Medium.sfd

--- a/Tools/Trinity.Bold.pe
+++ b/Tools/Trinity.Bold.pe
@@ -1,0 +1,28 @@
+#!/usr/bin/fontforge
+
+Open($1);
+
+# These characters are malformed in the .sfd file, causing text in this font
+# to have too much space above it.  For now, just delete these characters
+#
+# The problem is as follows:
+#   hbar references h and a transformed Eth
+#   h is defined by a spline set
+#   Eth is defined by a spline set of a line, and a reference to D
+#   D is defined by a spline set
+#
+# RISC OS throws away the reference to D from Eth, and just uses Eth's spline
+# set of the line.  FontForge does not throw away the refernce to D
+#
+# The other characters below have the same problem, but with different
+# reference characters.
+Select("dcroat");
+Cut();
+Select("hbar");
+Cut();
+Select("Uring");
+Cut();
+Select("Atilde");
+Cut();
+
+Save();

--- a/Tools/fontmunge.pe
+++ b/Tools/fontmunge.pe
@@ -1,5 +1,12 @@
 #!/usr/bin/fontforge
 Open($1)
+#
+# Generate some acceptable TTF names for this font
+names = StrSplit($fontname, ".");
+fullname = StrJoin(names, " ");
+subfamily = StrSplit(Strsub($fontname, Strstr($fontname, ".") + 1), ".")
+family = names[0];
+fontname = family + "-" + StrJoin(subfamily, "");
 
 # Fix the winding rule issue with font plotting (filled in 'o' 'e' 'B' etc)
 SelectAll()
@@ -9,7 +16,7 @@ CorrectDirection()
 ClearHints()
 
 # Add in the copyright string
-SetFontNames("","","","","(c) RISC OS Developments Ltd, released under Apache License 2.0","1");
+SetFontNames(fontname,family,fullname,"","(c) RISC OS Developments Ltd, released under Apache License 2.0","1");
 
 # Stuff has changed for the better, save changes to the sfd
 Save()

--- a/Tools/fontmunge.pe
+++ b/Tools/fontmunge.pe
@@ -8,6 +8,17 @@ subfamily = StrSplit(Strsub($fontname, Strstr($fontname, ".") + 1), ".")
 family = names[0];
 fontname = family + "-" + StrJoin(subfamily, "");
 
+# If this is an Oblique font, then skew it at a reasonable angle
+if (Strstr($1, "Oblique") != -1)
+	SelectAll();
+	Skew(12)
+endif
+
+# Set the italic angle
+if (Strstr($1, "Italic") != -1)
+	SetItalicAngle(-15.5)
+endif
+
 # Fix the winding rule issue with font plotting (filled in 'o' 'e' 'B' etc)
 SelectAll()
 CorrectDirection()

--- a/Tools/fontmunge.pe
+++ b/Tools/fontmunge.pe
@@ -18,6 +18,21 @@ ClearHints()
 # Add in the copyright string
 SetFontNames(fontname,family,fullname,"","(c) RISC OS Developments Ltd, released under Apache License 2.0","1");
 
+# Set the StyleMap to help Windows decide which fonts are in a family
+if (Strstr($1, "Bold.Italic") != -1)
+	SetOS2Value("StyleMap", 0x21);
+elseif (Strstr($1, "Bold.Oblique") != -1)
+	SetOS2Value("StyleMap", 0x21);
+elseif (Strstr($1, "Bold") != -1)
+	SetOS2Value("StyleMap", 0x20);
+elseif (Strstr($1, "Italic") != -1)
+	SetOS2Value("StyleMap", 0x01);
+elseif (Strstr($1, "Oblique") != -1)
+	SetOS2Value("StyleMap", 0x01);
+else
+	SetOS2Value("StyleMap", 0x40);
+endif
+
 # Stuff has changed for the better, save changes to the sfd
 Save()
 


### PR DESCRIPTION
I modified the font names, added some code to convert the Oblique fonts, and added some bits to turn these fonts into a valid Windows font family.

I had to delete some malformed glyphs from Trinity Bold because they were breaking the font metrics, and I can't think of a quick fix.  The removed glyphs are fairly esoteric, so most people shouldn't notice.